### PR TITLE
Alt image

### DIFF
--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,7 +11,7 @@ spec:
             fieldPath: metadata.annotations['devops.cloud.ibm.com/build-number']
   steps:
     - name: simple-step
-      image: ubuntu
+      image: "icr.io/continuous-delivery/pipeline/pipeline-base-image\"
       command: ["/bin/bash", "-c"]
       args:
         - echo -e "Start Pipeline Run - Build Number $BUILD_NUMBER";

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,7 +11,7 @@ spec:
             fieldPath: metadata.annotations['devops.cloud.ibm.com/build-number']
   steps:
     - name: simple-step
-      image: "icr.io/continuous-delivery/pipeline/pipeline-base-image\"
+      image: icr.io/continuous-delivery/pipeline/pipeline-base-image
       command: ["/bin/bash", "-c"]
       args:
         - echo -e "Start Pipeline Run - Build Number $BUILD_NUMBER";


### PR DESCRIPTION
Use pipeline base image from icr.us.io, instead of docker.io. Due to problems pulling `ubuntu` image from docker.io on 11 Nov 2023